### PR TITLE
Update README to add FileSession driver issue fix in `getUserFromSession` snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ public function getUserFromSession($conn)
     // Create a new session handler for this client
     $session = (new SessionManager(App::getInstance()))->driver();
     
+    // fix issue https://github.com/laravel/framework/issues/24364
+    if (Config::get('session.driver') == 'file') {	
+	clearstatcache();
+    }
+    
     // Get the cookies
     $cookies = $conn->WebSocket->request->getCookies();
     


### PR DESCRIPTION
`FileSessionHandler` has an issue when used in long-running apps. It doesn't check session's file modification time correctly. See https://github.com/laravel/framework/issues/24364
I think It would be nice to warn the users about the issue in documentation.